### PR TITLE
Backend: updated and added to query filter for search API #18

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -231,21 +231,17 @@ app.get('/api/profile/me',
 //     });
 //     });
 
-// Unhandled requests which aren't for the API should serve index.html so
-// client-side routing using browserHistory can function
-app.get(/^(?!\/api(\/|$))/, (req, res) => {
-  const index = path.resolve(__dirname + '/../client/dist', 'index.html');
-  res.sendFile(index);
-});
-
 function queryFilter(qry) {
   const validQueries = {
     'gitHub.login': qry.login,
     'profile.skills.languages': qry.languages,
     'profile.skills.roles': qry.roles,
     'gitHub.name': qry.name,
-    'profile.social.linked_in': qry.linked_in,
-    'profile.social.twitter': qry.twitter,
+    'profile.linked_in': qry.linked_in,
+    'profile.twitter': qry.twitter,
+    'profile.email': qry.email,
+    'profile.location': qry.location,
+    'profile.company': qry.company
   };
 
   const result = {};
@@ -266,6 +262,13 @@ app.get('/api/search', (req, res) => {
   .then(user => {
     res.json(user);
   });
+});
+
+// Unhandled requests which aren't for the API should serve index.html so
+// client-side routing using browserHistory can function
+app.get(/^(?!\/api(\/|$))/, (req, res) => {
+  const index = path.resolve(__dirname + '/../client/dist', 'index.html');
+  res.sendFile(index);
 });
 
 (function runServer(dbUrl = process.env.TEST_DATABASE_URL, port = process.env.PORT) {


### PR DESCRIPTION
Fixes #18 `Fix search due to Schema change`

This is the new API query with the changes to the Schema for social media adding in a few other options:

```
const validQueries = {
    'gitHub.login': qry.login,
    'profile.skills.languages': qry.languages,
    'profile.skills.roles': qry.roles,
    'gitHub.name': qry.name,
    'profile.linked_in': qry.linked_in,
    'profile.twitter': qry.twitter,
    'profile.email': qry.email,
    'profile.location': qry.location,
    'profile.company': qry.company
  };
```
![Fall bun ready to get these queries done!](http://i.imgur.com/8DOwEU9.jpg)