### PR TITLE
Backend: needed to add closeServer and export out for tests

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -231,6 +231,7 @@ app.get(/^(?!\/api(\/|$))/, (req, res) => {
   res.sendFile(index);
 });
 
+// RUN SERVER
 (function runServer(dbUrl = process.env.TEST_DATABASE_URL, port = process.env.PORT) {
   return new Promise((resolve, reject) => {
     mongoose.connect(dbUrl, err => {
@@ -248,3 +249,24 @@ app.get(/^(?!\/api(\/|$))/, (req, res) => {
     });
   });
 })();
+
+// CLOSE SERVER
+function closeServer() {
+  return mongoose.disconnect().then(() => {
+    return new Promise((resolve, reject) => {
+      console.log("Closing server");
+      server.close(err => {
+        if (err) {
+          return reject(err);
+        }
+        resolve();
+      });
+    });
+  });
+}
+if (require.main === module) {
+  runServer().catch(err => console.error(err));
+}
+
+// Export out for tests
+module.exports = {app, runServer, closeServer};


### PR DESCRIPTION
Added in the `function closeServer()` and exported out `app, runServer, closeServer` so I can run tests with Mocha and Chai.

![Mocha and Chai bun looking for those exports](http://i.imgur.com/eDQFAkA.jpg)