### PR TITLE
Package: Semantic versioning to 1.0.0

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devcupid-client",
-  "version": "0.1.13",
+  "version": "1.0.0",
   "dependencies": {
     "react": "^15.6.1",
     "react-dom": "^15.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devcupid",
-  "version": "0.1.13",
+  "version": "1.0.0",
   "description": "A web app for developers/designers to find and create teams",
   "homepage": "https://github.com/thinkful-c11/devcupid#readme",
   "main": "index.js",


### PR DESCRIPTION
Reflecting the version number to 1.0.0 due to several major incompatible API changes and releasing this to production soon. We shouldn't be making any more incompatible API changes until at least after the final presentation so for backwards compatible functionality use minor versioning updates and for smaller backwards compatible bug fixes do patch versioning updates.